### PR TITLE
Arc diagram with accepting singleton vertices

### DIFF
--- a/R/arcplot.r
+++ b/R/arcplot.r
@@ -15,7 +15,7 @@
 #' @export
 #' @keywords internal
 graph_info <- 
-  function(edgelist, vertices, sorted = FALSE, decreasing = FALSE, 
+  function(edgelist, sorted = FALSE, decreasing = FALSE, 
            ordering = NULL, labels = NULL)
   {
     # ======================================================
@@ -27,17 +27,20 @@ graph_info <-
     
     num_edges = nrow(edgelist)
     # get nodes (this could be numeric or character)
-#    nodes = unique(as.vector(t(edgelist)))	
+    if(hasArgs(vertices)){
     #to deal with singleton nodes
-    node = vertices 
-    num_nodes = length(node)
+    nodes = vertices 
+    }else{
+    nodes = unique(as.vector(t(edgelist)))	
+    }
+    num_nodes = length(nodes)
     # check labels (i.e. node names)
     if (!is.null(labels))
     {
       if (length(labels) != num_nodes)
         stop("\nLength of 'labels' differs from number of nodes")
     } else {
-      labels = node
+      labels = nodes
     }
     
     # auxiliar order (this may change if sorted or ordering required)
@@ -77,7 +80,7 @@ graph_info <-
     
     ## output
     list(
-      nodes = node,
+      nodes = nodes,
       labels = labels,
       num_nodes = num_nodes,
       num_edges = num_edges,
@@ -369,7 +372,7 @@ min_max_margin <- function(radios, above)
 #'  }
 #'
 arcplot <- function(
-  edgelist, vertices, sorted = FALSE, decreasing = FALSE, ordering = NULL, 
+  edgelist, sorted = FALSE, decreasing = FALSE, ordering = NULL, 
   labels = NULL, horizontal = TRUE, above = NULL, 
   col.arcs = "#5998ff77", lwd.arcs = 1.8, lty.arcs = 1, 
   lend = 1, ljoin = 2, lmitre = 1, show.nodes = TRUE, pch.nodes = 19, 
@@ -379,8 +382,13 @@ arcplot <- function(
   outer = FALSE, adj = NA, padj = NA, axes = FALSE, ...)
 {
   # Get graph information
+  if(hasArg(vertices) { 
   nodes_edges = graph_info(edgelist, vertices = vertices, sorted = sorted, decreasing = decreasing, 
                            ordering = ordering, labels = labels)
+  }else{
+  nodes_edges = graph_info(edgelist, sorted = sorted, decreasing = decreasing, 
+                           ordering = ordering, labels = labels)
+  }
   
   nodes = nodes_edges$nodes
   num_nodes = nodes_edges$num_nodes
@@ -564,7 +572,7 @@ arcplot <- function(
 #'  }
 #'
 node_coords <- function(
-  edgelist, vertices, sorted = FALSE, decreasing = FALSE, ordering = NULL, 
+  edgelist, sorted = FALSE, decreasing = FALSE, ordering = NULL, 
   labels = NULL)
 {
   # Get graph information

--- a/R/arcplot.r
+++ b/R/arcplot.r
@@ -487,7 +487,7 @@ arcplot <- function(
   
  if(hasArg(main)){ 
   # open empty plot window
-  plot(0.5, 0.5, xlim = xlim, ylim = ylim, type = "n", main,
+  plot(0.5, 0.5, xlim = xlim, ylim = ylim, type = "n", main = main,
        xlab = "", ylab = "", axes = axes, ...)
  }else{
  plot(0.5, 0.5, xlim = xlim, ylim = ylim, type = "n", 

--- a/R/arcplot.r
+++ b/R/arcplot.r
@@ -372,7 +372,7 @@ min_max_margin <- function(radios, above)
 #'  }
 #'
 arcplot <- function(
-  edgelist, vertices, sorted = FALSE, decreasing = FALSE, ordering = NULL, 
+  edgelist, vertices, sorted = FALSE, decreasing = FALSE, ordering = NULL, main,
   labels = NULL, horizontal = TRUE, above = NULL, 
   col.arcs = "#5998ff77", lwd.arcs = 1.8, lty.arcs = 1, 
   lend = 1, ljoin = 2, lmitre = 1, show.nodes = TRUE, pch.nodes = 19, 
@@ -487,7 +487,7 @@ arcplot <- function(
   
   
   # open empty plot window
-  plot(0.5, 0.5, xlim = xlim, ylim = ylim, type = "n", 
+  plot(0.5, 0.5, xlim = xlim, ylim = ylim, type = "n", main = main
        xlab = "", ylab = "", axes = axes, ...)
   # add each edge
   for (i in 1L:num_edges)

--- a/R/arcplot.r
+++ b/R/arcplot.r
@@ -15,7 +15,7 @@
 #' @export
 #' @keywords internal
 graph_info <- 
-  function(edgelist, sorted = FALSE, decreasing = FALSE, 
+  function(edgelist, vertices, sorted = FALSE, decreasing = FALSE, 
            ordering = NULL, labels = NULL, ... )
   {
     # ======================================================
@@ -372,7 +372,7 @@ min_max_margin <- function(radios, above)
 #'  }
 #'
 arcplot <- function(
-  edgelist, sorted = FALSE, decreasing = FALSE, ordering = NULL, 
+  edgelist, vertices, sorted = FALSE, decreasing = FALSE, ordering = NULL, 
   labels = NULL, horizontal = TRUE, above = NULL, 
   col.arcs = "#5998ff77", lwd.arcs = 1.8, lty.arcs = 1, 
   lend = 1, ljoin = 2, lmitre = 1, show.nodes = TRUE, pch.nodes = 19, 

--- a/R/arcplot.r
+++ b/R/arcplot.r
@@ -15,7 +15,7 @@
 #' @export
 #' @keywords internal
 graph_info <- 
-  function(edgelist, sorted = FALSE, decreasing = FALSE, 
+  function(edgelist, vertices, sorted = FALSE, decreasing = FALSE, 
            ordering = NULL, labels = NULL)
   {
     # ======================================================
@@ -27,15 +27,17 @@ graph_info <-
     
     num_edges = nrow(edgelist)
     # get nodes (this could be numeric or character)
-    nodes = unique(as.vector(t(edgelist)))
-    num_nodes = length(nodes)
+#    nodes = unique(as.vector(t(edgelist)))	
+    #to deal with singleton nodes
+    node = vertices 
+    num_nodes = length(node)
     # check labels (i.e. node names)
     if (!is.null(labels))
     {
       if (length(labels) != num_nodes)
         stop("\nLength of 'labels' differs from number of nodes")
     } else {
-      labels = nodes
+      labels = node
     }
     
     # auxiliar order (this may change if sorted or ordering required)
@@ -75,7 +77,7 @@ graph_info <-
     
     ## output
     list(
-      nodes = nodes,
+      nodes = node,
       labels = labels,
       num_nodes = num_nodes,
       num_edges = num_edges,
@@ -367,7 +369,7 @@ min_max_margin <- function(radios, above)
 #'  }
 #'
 arcplot <- function(
-  edgelist, sorted = FALSE, decreasing = FALSE, ordering = NULL, 
+  edgelist, vertices, sorted = FALSE, decreasing = FALSE, ordering = NULL, 
   labels = NULL, horizontal = TRUE, above = NULL, 
   col.arcs = "#5998ff77", lwd.arcs = 1.8, lty.arcs = 1, 
   lend = 1, ljoin = 2, lmitre = 1, show.nodes = TRUE, pch.nodes = 19, 
@@ -377,7 +379,7 @@ arcplot <- function(
   outer = FALSE, adj = NA, padj = NA, axes = FALSE, ...)
 {
   # Get graph information
-  nodes_edges = graph_info(edgelist, sorted = sorted, decreasing = decreasing, 
+  nodes_edges = graph_info(edgelist, vertices = vertices, sorted = sorted, decreasing = decreasing, 
                            ordering = ordering, labels = labels)
   
   nodes = nodes_edges$nodes
@@ -562,7 +564,7 @@ arcplot <- function(
 #'  }
 #'
 node_coords <- function(
-  edgelist, sorted = FALSE, decreasing = FALSE, ordering = NULL, 
+  edgelist, vertices, sorted = FALSE, decreasing = FALSE, ordering = NULL, 
   labels = NULL)
 {
   # Get graph information

--- a/R/arcplot.r
+++ b/R/arcplot.r
@@ -270,6 +270,7 @@ min_max_margin <- function(radios, above)
 #' 
 #' @param edgelist basically a two-column matrix with edges 
 #' (see \code{\link{graph}})
+#' @param main the title of the plot
 #' @param sorted logical to indicate if nodes should be sorted 
 #' (default \code{FALSE})
 #' @param decreasing logical to indicate type of sorting 
@@ -487,7 +488,7 @@ arcplot <- function(
   
   
   # open empty plot window
-  plot(0.5, 0.5, xlim = xlim, ylim = ylim, type = "n", main = main,
+  plot(0.5, 0.5, xlim = xlim, ylim = ylim, type = "n", main,
        xlab = "", ylab = "", axes = axes, ...)
   # add each edge
   for (i in 1L:num_edges)

--- a/R/arcplot.r
+++ b/R/arcplot.r
@@ -382,7 +382,7 @@ arcplot <- function(
   outer = FALSE, adj = NA, padj = NA, axes = FALSE, ...)
 {
   # Get graph information
-  if(hasArg(vertices) { 
+  if(hasArg(vertices)) { 
   nodes_edges = graph_info(edgelist, vertices = vertices, sorted = sorted, decreasing = decreasing, 
                            ordering = ordering, labels = labels)
   }else{

--- a/R/arcplot.r
+++ b/R/arcplot.r
@@ -16,7 +16,7 @@
 #' @keywords internal
 graph_info <- 
   function(edgelist, sorted = FALSE, decreasing = FALSE, 
-           ordering = NULL, labels = NULL)
+           ordering = NULL, labels = NULL, ... )
   {
     # ======================================================
     # Checking arguments

--- a/R/arcplot.r
+++ b/R/arcplot.r
@@ -485,7 +485,7 @@ arcplot <- function(
     y_nodes = centers
   }
   
- if(hasArg(main){ 
+ if(hasArg(main)){ 
   # open empty plot window
   plot(0.5, 0.5, xlim = xlim, ylim = ylim, type = "n", main,
        xlab = "", ylab = "", axes = axes, ...)

--- a/R/arcplot.r
+++ b/R/arcplot.r
@@ -270,7 +270,6 @@ min_max_margin <- function(radios, above)
 #' 
 #' @param edgelist basically a two-column matrix with edges 
 #' (see \code{\link{graph}})
-#' @param main the title of the plot
 #' @param sorted logical to indicate if nodes should be sorted 
 #' (default \code{FALSE})
 #' @param decreasing logical to indicate type of sorting 
@@ -373,7 +372,7 @@ min_max_margin <- function(radios, above)
 #'  }
 #'
 arcplot <- function(
-  edgelist, vertices, sorted = FALSE, decreasing = FALSE, ordering = NULL, main,
+  edgelist, vertices, main, sorted = FALSE, decreasing = FALSE, ordering = NULL,
   labels = NULL, horizontal = TRUE, above = NULL, 
   col.arcs = "#5998ff77", lwd.arcs = 1.8, lty.arcs = 1, 
   lend = 1, ljoin = 2, lmitre = 1, show.nodes = TRUE, pch.nodes = 19, 
@@ -486,10 +485,14 @@ arcplot <- function(
     y_nodes = centers
   }
   
-  
+ if(hasArg(main){ 
   # open empty plot window
   plot(0.5, 0.5, xlim = xlim, ylim = ylim, type = "n", main,
        xlab = "", ylab = "", axes = axes, ...)
+ }else{
+ plot(0.5, 0.5, xlim = xlim, ylim = ylim, type = "n", 
+       xlab = "", ylab = "", axes = axes, ...)
+ }
   # add each edge
   for (i in 1L:num_edges)
   {

--- a/R/arcplot.r
+++ b/R/arcplot.r
@@ -27,7 +27,7 @@ graph_info <-
     
     num_edges = nrow(edgelist)
     # get nodes (this could be numeric or character)
-    if(hasArgs(vertices)){
+    if(hasArg(vertices)){
     #to deal with singleton nodes
     nodes = vertices 
     }else{

--- a/R/arcplot.r
+++ b/R/arcplot.r
@@ -487,7 +487,7 @@ arcplot <- function(
   
   
   # open empty plot window
-  plot(0.5, 0.5, xlim = xlim, ylim = ylim, type = "n", main = main
+  plot(0.5, 0.5, xlim = xlim, ylim = ylim, type = "n", main = main,
        xlab = "", ylab = "", axes = axes, ...)
   # add each edge
   for (i in 1L:num_edges)


### PR DESCRIPTION
Previously arcplot only generates a node if its reflected in the edgelist but this leaves out singleton nodes if present in the graph. Proposed new arguement `vertices` will accept a vector of vertex names corresponding with that in the edgelist. 
Similar to how igraph's graph.data.frame works 
